### PR TITLE
feat: add rewards providers and FinalityProvider support

### DIFF
--- a/client.go
+++ b/client.go
@@ -48,6 +48,9 @@ type Client interface {
 
 	eth2client.BeaconCommitteesProvider
 
+	eth2client.BlockRewardsProvider
+	eth2client.SyncCommitteeRewardsProvider
+
 	eth2client.SyncCommitteeSubscriptionsSubmitter
 	eth2client.SyncCommitteeMessagesSubmitter
 	eth2client.SyncCommitteeContributionProvider

--- a/client.go
+++ b/client.go
@@ -50,6 +50,8 @@ type Client interface {
 
 	eth2client.BlockRewardsProvider
 	eth2client.SyncCommitteeRewardsProvider
+	eth2client.AttestationRewardsProvider
+	eth2client.FinalityProvider
 
 	eth2client.SyncCommitteeSubscriptionsSubmitter
 	eth2client.SyncCommitteeMessagesSubmitter

--- a/go-eth2-client/client.go
+++ b/go-eth2-client/client.go
@@ -257,6 +257,22 @@ func (c *Client) BeaconCommittees(ctx context.Context, opts *api.BeaconCommittee
 	return checkResponse(provider.BeaconCommittees(ctx, opts))
 }
 
+func (c *Client) BlockRewards(ctx context.Context, opts *api.BlockRewardsOpts) (*api.Response[*apiv1.BlockRewards], error) {
+	provider, ok := c.service.(eth2client.BlockRewardsProvider)
+	if !ok {
+		return nil, ErrCallNotSupported
+	}
+	return checkResponse(provider.BlockRewards(ctx, opts))
+}
+
+func (c *Client) SyncCommitteeRewards(ctx context.Context, opts *api.SyncCommitteeRewardsOpts) (*api.Response[[]*apiv1.SyncCommitteeReward], error) {
+	provider, ok := c.service.(eth2client.SyncCommitteeRewardsProvider)
+	if !ok {
+		return nil, ErrCallNotSupported
+	}
+	return checkResponse(provider.SyncCommitteeRewards(ctx, opts))
+}
+
 func (c *Client) SubmitAggregateAttestations(ctx context.Context, opts *api.SubmitAggregateAttestationsOpts) error {
 	provider, ok := c.service.(eth2client.AggregateAttestationsSubmitter)
 	if !ok {

--- a/go-eth2-client/client.go
+++ b/go-eth2-client/client.go
@@ -273,6 +273,22 @@ func (c *Client) SyncCommitteeRewards(ctx context.Context, opts *api.SyncCommitt
 	return checkResponse(provider.SyncCommitteeRewards(ctx, opts))
 }
 
+func (c *Client) AttestationRewards(ctx context.Context, opts *api.AttestationRewardsOpts) (*api.Response[*apiv1.AttestationRewards], error) {
+	provider, ok := c.service.(eth2client.AttestationRewardsProvider)
+	if !ok {
+		return nil, ErrCallNotSupported
+	}
+	return checkResponse(provider.AttestationRewards(ctx, opts))
+}
+
+func (c *Client) Finality(ctx context.Context, opts *api.FinalityOpts) (*api.Response[*apiv1.Finality], error) {
+	provider, ok := c.service.(eth2client.FinalityProvider)
+	if !ok {
+		return nil, ErrCallNotSupported
+	}
+	return checkResponse(provider.Finality(ctx, opts))
+}
+
 func (c *Client) SubmitAggregateAttestations(ctx context.Context, opts *api.SubmitAggregateAttestationsOpts) error {
 	provider, ok := c.service.(eth2client.AggregateAttestationsSubmitter)
 	if !ok {

--- a/mocks/client.go
+++ b/mocks/client.go
@@ -220,6 +220,36 @@ func (_m *Client) BeaconCommittees(ctx context.Context, opts *api.BeaconCommitte
 	return r0, r1
 }
 
+// BlockRewards provides a mock function with given fields: ctx, opts
+func (_m *Client) BlockRewards(ctx context.Context, opts *api.BlockRewardsOpts) (*api.Response[*v1.BlockRewards], error) {
+	ret := _m.Called(ctx, opts)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BlockRewards")
+	}
+
+	var r0 *api.Response[*v1.BlockRewards]
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *api.BlockRewardsOpts) (*api.Response[*v1.BlockRewards], error)); ok {
+		return rf(ctx, opts)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *api.BlockRewardsOpts) *api.Response[*v1.BlockRewards]); ok {
+		r0 = rf(ctx, opts)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*api.Response[*v1.BlockRewards])
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *api.BlockRewardsOpts) error); ok {
+		r1 = rf(ctx, opts)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Domain provides a mock function with given fields: ctx, domainType, epoch
 func (_m *Client) Domain(ctx context.Context, domainType phase0.DomainType, epoch phase0.Epoch) (phase0.Domain, error) {
 	ret := _m.Called(ctx, domainType, epoch)
@@ -734,6 +764,36 @@ func (_m *Client) SyncCommitteeDuties(ctx context.Context, opts *api.SyncCommitt
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, *api.SyncCommitteeDutiesOpts) error); ok {
+		r1 = rf(ctx, opts)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// SyncCommitteeRewards provides a mock function with given fields: ctx, opts
+func (_m *Client) SyncCommitteeRewards(ctx context.Context, opts *api.SyncCommitteeRewardsOpts) (*api.Response[[]*v1.SyncCommitteeReward], error) {
+	ret := _m.Called(ctx, opts)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SyncCommitteeRewards")
+	}
+
+	var r0 *api.Response[[]*v1.SyncCommitteeReward]
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *api.SyncCommitteeRewardsOpts) (*api.Response[[]*v1.SyncCommitteeReward], error)); ok {
+		return rf(ctx, opts)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *api.SyncCommitteeRewardsOpts) *api.Response[[]*v1.SyncCommitteeReward]); ok {
+		r0 = rf(ctx, opts)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*api.Response[[]*v1.SyncCommitteeReward])
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *api.SyncCommitteeRewardsOpts) error); ok {
 		r1 = rf(ctx, opts)
 	} else {
 		r1 = ret.Error(1)

--- a/mocks/client.go
+++ b/mocks/client.go
@@ -100,6 +100,36 @@ func (_m *Client) AttestationData(ctx context.Context, opts *api.AttestationData
 	return r0, r1
 }
 
+// AttestationRewards provides a mock function with given fields: ctx, opts
+func (_m *Client) AttestationRewards(ctx context.Context, opts *api.AttestationRewardsOpts) (*api.Response[*v1.AttestationRewards], error) {
+	ret := _m.Called(ctx, opts)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AttestationRewards")
+	}
+
+	var r0 *api.Response[*v1.AttestationRewards]
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *api.AttestationRewardsOpts) (*api.Response[*v1.AttestationRewards], error)); ok {
+		return rf(ctx, opts)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *api.AttestationRewardsOpts) *api.Response[*v1.AttestationRewards]); ok {
+		r0 = rf(ctx, opts)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*api.Response[*v1.AttestationRewards])
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *api.AttestationRewardsOpts) error); ok {
+		r1 = rf(ctx, opts)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // AttesterDuties provides a mock function with given fields: ctx, opts
 func (_m *Client) AttesterDuties(ctx context.Context, opts *api.AttesterDutiesOpts) (*api.Response[[]*v1.AttesterDuty], error) {
 	ret := _m.Called(ctx, opts)
@@ -296,6 +326,36 @@ func (_m *Client) Events(ctx context.Context, opts *api.EventsOpts) error {
 	}
 
 	return r0
+}
+
+// Finality provides a mock function with given fields: ctx, opts
+func (_m *Client) Finality(ctx context.Context, opts *api.FinalityOpts) (*api.Response[*v1.Finality], error) {
+	ret := _m.Called(ctx, opts)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Finality")
+	}
+
+	var r0 *api.Response[*v1.Finality]
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *api.FinalityOpts) (*api.Response[*v1.Finality], error)); ok {
+		return rf(ctx, opts)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *api.FinalityOpts) *api.Response[*v1.Finality]); ok {
+		r0 = rf(ctx, opts)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*api.Response[*v1.Finality])
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *api.FinalityOpts) error); ok {
+		r1 = rf(ctx, opts)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // Genesis provides a mock function with given fields: ctx, opts

--- a/pool/methods.go
+++ b/pool/methods.go
@@ -81,6 +81,28 @@ func (m *methods) AttestationData(ctx context.Context, opts *api.AttestationData
 	return _result.pp1, _result.err
 }
 
+func (m *methods) AttestationRewards(ctx context.Context, opts *api.AttestationRewardsOpts) (pp1 *api.Response[*apiv1.AttestationRewards], err error) {
+	ctx = context.WithValue(ctx, methodCtxKey{}, "AttestationRewards")
+	type _resultStruct struct {
+		pp1 *api.Response[*apiv1.AttestationRewards]
+		err error
+	}
+	var _result, _unchecked _resultStruct
+	var _mutex sync.Mutex
+	_result.err = m.callFunc(ctx, func(ctx context.Context, client beacon.Client) error {
+		pp1, err := client.AttestationRewards(ctx, opts)
+		_mutex.Lock()
+		defer _mutex.Unlock()
+		_unchecked = _resultStruct{pp1, err}
+		if err != nil {
+			return err
+		}
+		_result = _unchecked
+		return nil
+	})
+	return _result.pp1, _result.err
+}
+
 func (m *methods) AttesterDuties(ctx context.Context, opts *api.AttesterDutiesOpts) (pp1 *api.Response[[]*apiv1.AttesterDuty], err error) {
 	ctx = context.WithValue(ctx, methodCtxKey{}, "AttesterDuties")
 	type _resultStruct struct {
@@ -232,6 +254,28 @@ func (m *methods) Events(ctx context.Context, opts *api.EventsOpts) (err error) 
 		return nil
 	})
 	return _result.err
+}
+
+func (m *methods) Finality(ctx context.Context, opts *api.FinalityOpts) (pp1 *api.Response[*apiv1.Finality], err error) {
+	ctx = context.WithValue(ctx, methodCtxKey{}, "Finality")
+	type _resultStruct struct {
+		pp1 *api.Response[*apiv1.Finality]
+		err error
+	}
+	var _result, _unchecked _resultStruct
+	var _mutex sync.Mutex
+	_result.err = m.callFunc(ctx, func(ctx context.Context, client beacon.Client) error {
+		pp1, err := client.Finality(ctx, opts)
+		_mutex.Lock()
+		defer _mutex.Unlock()
+		_unchecked = _resultStruct{pp1, err}
+		if err != nil {
+			return err
+		}
+		_result = _unchecked
+		return nil
+	})
+	return _result.pp1, _result.err
 }
 
 func (m *methods) Genesis(ctx context.Context, opts *api.GenesisOpts) (pp1 *api.Response[*apiv1.Genesis], err error) {

--- a/pool/methods.go
+++ b/pool/methods.go
@@ -169,6 +169,28 @@ func (m *methods) BeaconCommittees(ctx context.Context, opts *api.BeaconCommitte
 	return _result.pp1, _result.err
 }
 
+func (m *methods) BlockRewards(ctx context.Context, opts *api.BlockRewardsOpts) (pp1 *api.Response[*apiv1.BlockRewards], err error) {
+	ctx = context.WithValue(ctx, methodCtxKey{}, "BlockRewards")
+	type _resultStruct struct {
+		pp1 *api.Response[*apiv1.BlockRewards]
+		err error
+	}
+	var _result, _unchecked _resultStruct
+	var _mutex sync.Mutex
+	_result.err = m.callFunc(ctx, func(ctx context.Context, client beacon.Client) error {
+		pp1, err := client.BlockRewards(ctx, opts)
+		_mutex.Lock()
+		defer _mutex.Unlock()
+		_unchecked = _resultStruct{pp1, err}
+		if err != nil {
+			return err
+		}
+		_result = _unchecked
+		return nil
+	})
+	return _result.pp1, _result.err
+}
+
 func (m *methods) Domain(ctx context.Context, domainType phase0.DomainType, epoch phase0.Epoch) (d1 phase0.Domain, err error) {
 	ctx = context.WithValue(ctx, methodCtxKey{}, "Domain")
 	type _resultStruct struct {
@@ -598,6 +620,28 @@ func (m *methods) SyncCommitteeDuties(ctx context.Context, opts *api.SyncCommitt
 	var _mutex sync.Mutex
 	_result.err = m.callFunc(ctx, func(ctx context.Context, client beacon.Client) error {
 		pp1, err := client.SyncCommitteeDuties(ctx, opts)
+		_mutex.Lock()
+		defer _mutex.Unlock()
+		_unchecked = _resultStruct{pp1, err}
+		if err != nil {
+			return err
+		}
+		_result = _unchecked
+		return nil
+	})
+	return _result.pp1, _result.err
+}
+
+func (m *methods) SyncCommitteeRewards(ctx context.Context, opts *api.SyncCommitteeRewardsOpts) (pp1 *api.Response[[]*apiv1.SyncCommitteeReward], err error) {
+	ctx = context.WithValue(ctx, methodCtxKey{}, "SyncCommitteeRewards")
+	type _resultStruct struct {
+		pp1 *api.Response[[]*apiv1.SyncCommitteeReward]
+		err error
+	}
+	var _result, _unchecked _resultStruct
+	var _mutex sync.Mutex
+	_result.err = m.callFunc(ctx, func(ctx context.Context, client beacon.Client) error {
+		pp1, err := client.SyncCommitteeRewards(ctx, opts)
 		_mutex.Lock()
 		defer _mutex.Unlock()
 		_unchecked = _resultStruct{pp1, err}


### PR DESCRIPTION
## Summary
- Add `BlockRewardsProvider` and `SyncCommitteeRewardsProvider` for fetching block and sync committee rewards
- Add `AttestationRewardsProvider` for fetching attestation rewards per validator
- Add `FinalityProvider` for fetching finality checkpoint data

These providers enable validator rewards indexing in ethereum2-monitor (e2m).

## Changes
- Added provider interfaces to `client.go`
- Added method implementations to `go-eth2-client/client.go`
- Regenerated mocks and pool methods via `make tool`

🤖 Generated with [Claude Code](https://claude.com/claude-code)